### PR TITLE
caching resource details parsing

### DIFF
--- a/src/proxy/Program.cs
+++ b/src/proxy/Program.cs
@@ -18,16 +18,12 @@ builder.Services.AddHttpClient(AzureOpenAIPassiveHealthCheckPolicy.HttpClientNam
 // Export metrics from all HTTP clients registered in services
 builder.Services.UseHttpClientMetrics();
 
+builder.Services.AddPrometheusServices();
+
 WebApplication app = builder.Build();
 
 app.MapReverseProxy();
 
-// Add middleware to handle scraping requests for metrics
-app.UseHttpMetrics();
-
-// Enable the /metrics page to export Prometheus metrics
-app.MapMetrics();
-
-app.UsePrometheusPublisherMiddleware();
+app.UsePrometheusMetrics();
 
 app.Run();

--- a/src/proxy/Proxy.csproj
+++ b/src/proxy/Proxy.csproj
@@ -13,6 +13,12 @@
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.6" /> 
     <PackageReference Include="prometheus-net.AspNetCore" Version="8.2.1" />
     <PackageReference Include="Yarp.ReverseProxy" Version="2.1.0" />
-   </ItemGroup> 
+   </ItemGroup>
+
+  <ItemGroup>
+    <Content Update="appsettings.Local.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup> 
 
 </Project>

--- a/src/proxy/Telemetry/PrometheusPublisherMiddleware.cs
+++ b/src/proxy/Telemetry/PrometheusPublisherMiddleware.cs
@@ -1,4 +1,6 @@
-﻿using Proxy.Models;
+﻿using Microsoft.Extensions.Caching.Memory;
+using Prometheus;
+using Proxy.Models;
 using Proxy.OpenAI;
 using Proxy.Transformers;
 
@@ -8,7 +10,7 @@ public class PrometheusPublisherMiddleware(RequestDelegate next)
 {
     private readonly RequestDelegate _next = next;
 
-    public async Task InvokeAsync(HttpContext context)
+    public async Task InvokeAsync(HttpContext context, IMemoryCache cache)
     {
         await _next(context);
 
@@ -16,8 +18,7 @@ public class PrometheusPublisherMiddleware(RequestDelegate next)
         {
             string destinationAddress = values.ToString();
 
-            string accountName = GetAccountNameFromDestination(destinationAddress);
-            string deploymentName = GetDeploymentNameFromDestination(destinationAddress);
+            (string accountName, string deploymentName) = GetResourceDetailsFromDestination(cache, destinationAddress);
 
             if (context.Response.StatusCode is >= 400 and <= 599)
             {
@@ -40,25 +41,53 @@ public class PrometheusPublisherMiddleware(RequestDelegate next)
         }
     }
 
-    private static string GetDeploymentNameFromDestination(string destinationAddress)
+    private static ResourceDetails GetResourceDetailsFromDestination(IMemoryCache cache, string destinationAddress)
     {
+        if (cache.TryGetValue(destinationAddress, out ResourceDetails resourceDetails))
+            return resourceDetails;
+
         Uri uri = new(destinationAddress);
+
+        string accountName = uri.Host.Split('.')[0].Replace('-', '_');
 
         string[] pathSegments = uri.AbsolutePath.Trim('/').Split('/');
-        return pathSegments[^1].Replace('-', '_');
+        string deploymentName = pathSegments[^1].Replace('-', '_');
+
+        return cache.Set(destinationAddress, new ResourceDetails()
+        {
+            AccountName = accountName,
+            DeploymentName = deploymentName
+        }, TimeSpan.FromHours(1)); // 1h to avoid memory leaks, in case a single proxy instance keeps refreshing its destination list
     }
 
-    private static string GetAccountNameFromDestination(string destinationAddress)
+    private readonly struct ResourceDetails
     {
-        Uri uri = new(destinationAddress);
-        return uri.Host.Split('.')[0].Replace('-', '_');
+        public string AccountName { get; init; }
+        public string DeploymentName { get; init; }
+
+        public void Deconstruct(out string accountName, out string deploymentName)
+        {
+            accountName = AccountName;
+            deploymentName = DeploymentName;
+        }
     }
 }
 
 public static class PrometheusPublisherMiddlewareExtensions
 {
-    public static IApplicationBuilder UsePrometheusPublisherMiddleware(this IApplicationBuilder builder)
+    public static IServiceCollection AddPrometheusServices(this IServiceCollection services)
     {
-        return builder.UseMiddleware<PrometheusPublisherMiddleware>();
+        return services.AddMemoryCache();
+    }
+
+    public static IApplicationBuilder UsePrometheusMetrics(this WebApplication app)
+    {
+        // Add middleware to handle scraping requests for metrics
+        app.UseHttpMetrics();
+
+        // Enable the /metrics page to export Prometheus metrics
+        app.MapMetrics();
+
+        return app.UseMiddleware<PrometheusPublisherMiddleware>();
     }
 }


### PR DESCRIPTION
Every time the passive health check (now this Prometheus middleware) received a request, we were parsing the resource details (account and deployment names). A lot of intermediate strings were going to be generated, and may put some load on the GC. I propose we use an in-memory cache to parse it once.